### PR TITLE
using PIXELS_SRC to replace the relative path

### DIFF
--- a/examples/parquet-example/CMakeLists.txt
+++ b/examples/parquet-example/CMakeLists.txt
@@ -6,7 +6,6 @@ include_directories(../../third_party/catch)
 include_directories(../../third_party/tpce-tool/include)
 include_directories(../../third_party/sqlite/include)
 include_directories(../../src/include)
-#include_directories(../../../pixels-common/include)
 
 add_executable(parquet-example main.cpp)
 target_link_libraries(parquet-example duckdb)

--- a/examples/pixels-example/CMakeLists.txt
+++ b/examples/pixels-example/CMakeLists.txt
@@ -6,7 +6,7 @@ include_directories(../../third_party/catch)
 include_directories(../../third_party/tpce-tool/include)
 include_directories(../../third_party/sqlite/include)
 include_directories(../../src/include)
-include_directories(../../../pixels-common/include)
+include_directories($ENV{PIXELS_SRC}/cpp/pixels-common/include)
 
 add_executable(pixels-example main.cpp)
 target_link_libraries(pixels-example duckdb)

--- a/extension/extension_config.cmake
+++ b/extension/extension_config.cmake
@@ -11,7 +11,7 @@
 duckdb_extension_load(parquet)
 duckdb_extension_load(tpch)
 duckdb_extension_load(pixels
-    SOURCE_DIR ../../
+    SOURCE_DIR $ENV{PIXELS_SRC}
 )
 
 # The Linux allocator has issues so we use jemalloc, but only on x86 because page sizes are fixed at 4KB.

--- a/scripts/parquet-multidir-generator.py
+++ b/scripts/parquet-multidir-generator.py
@@ -6,7 +6,7 @@ import shutil
 # The script copies all files in ${input}/${table}/${suffix}/ directory to ${output}/${table}/${suffix}/
 # input, output and suffix should be designated, while table is detected automatically.
 # For example, we execute the following script:
-# cd pixels-duckdb
+# cd pixels-duckdb/duckdb
 # python scripts/parquet-multidir-generator.py -i /data/tpch-300 -o /data1/tpch-300-partition1 /data2/tpch-300-partition2
 # The input path layout is:
 # input:

--- a/scripts/pixels-multidir-generator.py
+++ b/scripts/pixels-multidir-generator.py
@@ -6,7 +6,7 @@ import shutil
 # The script copies all files in ${input}/${table}/${suffix}/ directory to ${output}/${table}/${suffix}/
 # input, output and suffix should be designated, while table is detected automatically.
 # For example, we execute the following script:
-# cd pixels-duckdb
+# cd pixels-duckdb/duckdb
 # python scripts/pixels-multidir-generator.py -i /data/tpch-300 -o /data1/tpch-300-partition1 /data2/tpch-300-partition2
 # The input path layout is:
 # input:


### PR DESCRIPTION
Previously, duckdb used the relative path to find pixels source path, this makes the compilation unflexible.